### PR TITLE
Reimplemented reachability analysis algorithm using work collection

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -119,6 +119,9 @@ Library "pds-reachability"
     Pds_reachability_structure,
     Pds_reachability_types,
     Pds_reachability_types_stack,
+    Pds_reachability_work,
+    Pds_reachability_work_collection,
+    Pds_reachability_work_collection_templates,
     Pds_reachability
   BuildDepends:
     utils,

--- a/src/analysis/analysis.ml
+++ b/src/analysis/analysis.ml
@@ -27,8 +27,7 @@ sig
   module C : Context_stack;;
 
   (** The initial, unclosed analysis derived from an expression. *)
-  val create_initial_analysis :
-    ?logging_prefix:string option -> expr -> ddpa_analysis
+  val create_initial_analysis : expr -> ddpa_analysis
 
   (** Pretty-prints a DDPA structure. *)
   val pp_ddpa_analysis : ddpa_analysis pretty_printer
@@ -1626,14 +1625,11 @@ struct
     pds_edge_count
   ;;
 
-  let empty_analysis logging_prefix_opt =
+  let empty_analysis =
     (* The initial reachability analysis should include an edge function which
        always allows discarding the bottom-of-stack marker. *)
-    let empty_reachability =
-      Ddpa_pds_reachability.empty ~logging_prefix:logging_prefix_opt ()
-    in
     let initial_reachability =
-      empty_reachability
+      Ddpa_pds_reachability.empty
       |> Ddpa_pds_reachability.add_edge_function
         (fun state -> Enum.singleton ([Pop Bottom_of_stack], state))
     in
@@ -2293,7 +2289,7 @@ struct
       )
   ;;
 
-  let create_initial_analysis ?logging_prefix:(logging_prefix=None) e =
+  let create_initial_analysis e =
     let Abs_expr(cls) = lift_expr e in
     (* Put the annotated clauses together. *)
     let acls =
@@ -2313,18 +2309,7 @@ struct
           Ddpa_edge(acl1,acl2) :: mk_edges acls'
     in
     let edges = List.enum @@ mk_edges acls in
-    let empty_analysis' =
-      match logging_prefix with
-      | None -> empty_analysis None
-      | Some prefix ->
-        { (empty_analysis @@ Some prefix) with
-          ddpa_logging_data = Some
-              { ddpa_closure_steps = 0
-              ; ddpa_logging_prefix = prefix
-              }
-        }
-    in
-    let analysis = fst @@ add_edges edges empty_analysis' in
+    let analysis = fst @@ add_edges edges empty_analysis in
     logger `trace "Created initial analysis";
     log_ddpa_graph Ddpa_graph_logger.Ddpa_log_all analysis
       (fun data ->
@@ -2538,10 +2523,12 @@ struct
   ;;
 
   let set_pdr_logger_level level =
-    Ddpa_pds_reachability.set_logging_level level
+    (* TODO: rewrite logging mechanism for PDR *)
+    ignore level; raise @@ Utils.Not_yet_implemented "set_pdr_logger_level"
   ;;
 
   let get_pdr_logger_level () =
-    Ddpa_pds_reachability.get_logging_level ()
+    (* TODO: rewrite logging mechanism for PDR *)
+    raise @@ Utils.Not_yet_implemented "get_pdr_logger_level"
   ;;
 end;;

--- a/src/analysis/analysis.ml
+++ b/src/analysis/analysis.ml
@@ -1572,7 +1572,10 @@ struct
   end;;
 
   module Ddpa_pds_reachability =
-    Pds_reachability.Make(Ddpa_pds_reachability_basis)(Dph)
+    Pds_reachability.Make
+      (Ddpa_pds_reachability_basis)
+      (Dph)
+      (Pds_reachability_work_collection_templates.Work_stack)
   ;;
 
   type ddpa_analysis_logging_data =

--- a/src/analysis/analysis.ml
+++ b/src/analysis/analysis.ml
@@ -2348,6 +2348,7 @@ struct
     let analysis' = { analysis with pds_reachability = reachability' } in
     let values =
       reachability'
+      |> Ddpa_pds_reachability.fully_close
       |> Ddpa_pds_reachability.get_reachable_states start_state start_actions
       |> Enum.filter_map
         (function

--- a/src/analysis/analysis.ml
+++ b/src/analysis/analysis.ml
@@ -2344,11 +2344,11 @@ struct
     let reachability' =
       reachability
       |> Ddpa_pds_reachability.add_start_state start_state start_actions
+      |> Ddpa_pds_reachability.fully_close
     in
     let analysis' = { analysis with pds_reachability = reachability' } in
     let values =
       reachability'
-      |> Ddpa_pds_reachability.fully_close
       |> Ddpa_pds_reachability.get_reachable_states start_state start_actions
       |> Enum.filter_map
         (function

--- a/src/pds-reachability/pds_reachability_analysis.ml
+++ b/src/pds-reachability/pds_reachability_analysis.ml
@@ -138,36 +138,97 @@ struct
   end;;
 
   module Node_set = Set.Make(Node_ord);;
+  module Node_map = Map.Make(Node_ord);;
 
   (********** Define analysis structure. **********)
 
-  type analysis_logging_data =
-    { analysis_logging_prefix : string
-    ; major_log_index : int
-    ; minor_log_index : int
-    }
+  type node_awareness =
+    | Seen
+    (* Indicates that this node exists somewhere in the work queue but not in
+       the analysis structure. *)
+    | Expanded
+    (* Indicates that this node exists somewhere in the analysis structure and
+       has already been expanded.  An expanded node responds to edge functions,
+       for instance. *)
     [@@deriving show]
-  ;;
-  let _show_analysis_logging_data = show_analysis_logging_data;;
+  let _ = show_node_awareness;; (* To ignore an unused generated function. *)
 
   type analysis =
-    { known_nodes : Node_set.t
-          [@printer fun formatter nodes ->
-                 pp_concat_sep_delim "{" "}" "," pp_node formatter @@
-                 Node_set.enum nodes]
+    { node_awareness_map : node_awareness Node_map.t
+          [@printer Pp_utils.pp_map pp_node pp_node_awareness Node_map.enum]
+    (* A mapping from each node to whether the analysis is aware of it.  Any node
+       not in this map has not been seen in any fashion.  Every node that has been
+       seen will be mapped to an appropriate [node_awareness] value. *)
+    ; known_states : State_set.t
+          [@printer Pp_utils.pp_set Basis.pp_state State_set.enum]
+    (* A collection of all states appearing somewhere within the reachability
+       structure (whether they have been expanded or not). *)
     ; reachability : Structure.structure
+    (* The underlying structure maintaining the nodes and edges in the graph. *)
     ; edge_functions : edge_function list
           [@printer fun formatter functions ->
                  Format.fprintf formatter "(length = %d)"
                    (List.length functions)]
+    (* The list of all edge functions for this analysis. *)
     ; untargeted_dynamic_pop_action_functions :
         untargeted_dynamic_pop_action_function list
           [@printer fun formatter functions ->
                  Format.fprintf formatter "(length = %d)"
                    (List.length functions)]
+    (* The list of all untargeted dynamic pop action functions. *)
     ; work_collection : Work_collection_impl.work_collection
+    (* The collection of work which has not yet been performed. *)
     }
     [@@deriving show]
+  ;;
+
+  (********** Analysis utility functions. **********)
+
+  let add_work work analysis =
+    match work with
+    | Work.Expand_node node ->
+      if Node_map.mem node analysis.node_awareness_map
+      then analysis
+      else
+        { analysis with
+          work_collection =
+            Work_collection_impl.offer work analysis.work_collection
+        ; node_awareness_map =
+            Node_map.add node Seen analysis.node_awareness_map
+        }
+    | Work.Introduce_edge edge ->
+      (* TODO: We might want to filter duplicate introduce-edge steps from the
+         work collection. *)
+      if Structure.has_edge edge analysis.reachability
+      then analysis
+      else
+        { analysis with
+          work_collection =
+            Work_collection_impl.offer work analysis.work_collection
+        }
+    | Work.Introduce_untargeted_dynamic_pop(from_node,action) ->
+      (* TODO: We might want to filter duplicate introduce-udynpop steps from
+         the work collection. *)
+      if Structure.has_untargeted_dynamic_pop_action
+          from_node action analysis.reachability
+      then analysis
+      else
+        { analysis with
+          work_collection =
+            Work_collection_impl.offer work analysis.work_collection
+        }
+  ;;
+
+  let add_works works analysis = Enum.fold (flip add_work) analysis works;;
+
+  let next_edge_in_sequence from_node actions to_node =
+    let next_node,action =
+      match actions with
+      | [] -> to_node,Nop
+      | [x] -> to_node,x
+      | x::xs -> Intermediate_node(to_node,xs),x
+    in
+    {source=from_node;target=next_node;edge_action=action}
   ;;
 
   (********** Define analysis operations. **********)
@@ -180,391 +241,93 @@ struct
   ;;
 
   let empty =
-    { known_nodes = Node_set.empty
+    { node_awareness_map = Node_map.empty
+    ; known_states = State_set.empty
     ; reachability = Structure.empty
     ; edge_functions = []
     ; untargeted_dynamic_pop_action_functions = []
     ; work_collection = Work_collection_impl.empty
     };;
 
-  (** Adds a "real" edge (the PDS reachability structure's edge, not the
-      analysis interface's presentation of an edge) to an analysis.  Then,
-      performs edge closure on the analysis. *)
-  let rec add_real_edge_and_close edge analysis =
-    Logger_utils.lazy_bracket_log (lazy_logger `trace)
-      (fun () -> "add_real_edge_and_close " ^ show_edge edge)
-      (fun _ -> "Finished") @@
-    fun () ->
-    (* If we already have this edge, ignore the addition.  In particular, we can
-       get an infinite loop (resulting in stack overflow) if we allow the
-       closure to proceed. *)
-    if Structure.has_edge edge analysis.reachability then analysis else
-      (* First, add this edge to the lookup structures. *)
-      let analysis' =
-        { analysis with
-          reachability = Structure.add_edge edge analysis.reachability
-        }
-      in
-      (* Now that this edge is added, we need to consider other edges which may
-         arise directly from its presence.  This edge introduces a target node;
-         if we have not yet seen that target, we have not executed the edge
-         functions on it.  We should do this for nodes of push and nop edges
-         because they are "alive": there is necessarily a path from a starting
-         node to reach them due to how edges are added to the analysis.  We do
-         not do this for pop edges, instead waiting until the pop is canceled by
-         a push during closure (see below). *)
-      let analysis'' =
-        match edge.edge_action with
-        | Nop | Push _ -> add_node edge.source @@ add_node edge.target analysis'
-        | Pop _ | Pop_dynamic_targeted _ -> analysis'
-      in
-      (* Next, we need to perform edge closure.  The particular action depends
-         on this new edge's action.  The closure rules are summarized below.
-          1. (a) -- push a --> (b) -- pop a --> (c) ==> (a) -- nop --> (c)
-          2. (a) -- push a --> (b) -- nop --> (c) ==> (a) -- push a --> (c)
-          3. (a) -- nop --> (b) -- nop --> (c) ==> (a) -- nop --> (c)
-          4. (a) -- push a --> (b) -- targeted_dynamic_pop f --> (c) ==>
-              (a) -- action_1 --> ... -- action_n --> (c)
-             for each [action_1,...,action_n] in f a
-          5. (a) -- push a --> (b) -- untargeted_dynamic_pop f ==>
-              (a) -- action_1 --> ... -- action_n --> (c)
-             for each ([action_1,...,action_n],c) in f a
-      *)
-      (* more_edges is an enumeration containing edges which are immediately
-         known *)
-      let more_edges =
-        match edge.edge_action with
-        | Nop ->
-          let push_into_source =
-            analysis''.reachability
-            |> Structure.find_push_edges_by_target edge.source
-            |> Enum.map
-              (fun (source',element) ->
-                 { source = source'; target = edge.target
-                 ; edge_action = Push element
-                 })
-          in
-          let nop_into_source =
-            analysis''.reachability
-            |> Structure.find_nop_edges_by_target edge.source
-            |> Enum.map
-              (fun source' ->
-                 { source = source'; target = edge.target; edge_action = Nop })
-          in
-          let nop_out_of_target =
-            analysis''.reachability
-            |> Structure.find_nop_edges_by_source edge.target
-            |> Enum.map
-              (fun target' ->
-                 { source = edge.source; target = target'; edge_action = Nop })
-          in
-          Enum.concat @@ List.enum
-            [ push_into_source; nop_into_source; nop_out_of_target ]
-        | Push element as act ->
-          let nop_out_of_target =
-            analysis''.reachability
-            |> Structure.find_nop_edges_by_source edge.target
-            |> Enum.map
-              (fun target' ->
-                 { source = edge.source; target = target'; edge_action = act })
-          in
-          let pop_out_of_target =
-            analysis''.reachability
-            |> Structure.find_pop_edges_by_source_and_element
-              edge.target element
-            |> Enum.map
-              (fun target' ->
-                 { source = edge.source; target = target'; edge_action = Nop })
-          in
-          Enum.append nop_out_of_target pop_out_of_target
-        | Pop element ->
-          let push_into_source =
-            analysis''.reachability
-            |> Structure.find_push_edges_by_target_and_element
-              edge.source element
-            |> Enum.map
-              (fun source' ->
-                 { source = source'; target = edge.target; edge_action = Nop })
-          in
-          push_into_source
-        | Pop_dynamic_targeted _ -> Enum.empty ()
-      in
-      (* analysis_updates is an enumeration of functions which will update the
-         analysis by adding edges.  This is appropriate when e.g. new
-         intermediate nodes must be created. *)
-      let analysis_updates =
-        match edge.edge_action with
-        | Nop -> Enum.empty ()
-        | Push element ->
-          let targeted_dynamic_pop_out_of_target =
-            analysis''.reachability
-            |> Structure.find_targeted_dynamic_pop_edges_by_source edge.target
-            |> Enum.map
-              (fun (target', action) ->
-                 fun (analysis : analysis) ->
-                   Dph.perform_targeted_dynamic_pop element action
-                   |> Enum.fold
-                     (fun analysis' actions ->
-                        add_edges_between_nodes
-                          edge.source target' actions analysis')
-                     analysis
-              )
-          in
-          let untargeted_dynamic_pop_out_of_target =
-            analysis''.reachability
-            |> Structure.find_untargeted_dynamic_pop_actions_by_source
-              edge.target
-            |> Enum.map (Dph.perform_untargeted_dynamic_pop element)
-            |> Enum.concat
-            |> Enum.map
-              (fun (path, target) ->
-                 let target_node = State_node target in
-                 add_edges_between_nodes edge.source target_node path)
-          in
-          Enum.append
-            untargeted_dynamic_pop_out_of_target
-            targeted_dynamic_pop_out_of_target
-        | Pop _ -> Enum.empty ()
-        | Pop_dynamic_targeted action ->
-          let push_into_source =
-            analysis''.reachability
-            |> Structure.find_push_edges_by_target edge.source
-            |> Enum.map
-              (fun (source, element) ->
-                 fun analysis ->
-                   Dph.perform_targeted_dynamic_pop element action
-                   |> Enum.fold
-                     (fun analysis' actions ->
-                        add_edges_between_nodes
-                          source edge.target actions analysis')
-                     analysis
-              )
-          in
-          push_into_source
-      in
-      let analysis_after_edges =
-        more_edges
-        |> Enum.fold (flip add_real_edge_and_close) analysis''
-      in
-      let analysis_after_updates =
-        analysis_updates
-        |> Enum.fold (fun a f -> f a) analysis_after_edges
-      in
-      analysis_after_updates
-
-  (**
-     Adds a sequence of edges between two nodes in the analysis.  This is
-     accomplished by introducing intermediate nodes as necessary.
-  *)
-  and add_edges_between_nodes source_node target_node stack_actions analysis =
-    Logger_utils.lazy_bracket_log (lazy_logger `trace)
-      (fun () ->
-         Printf.sprintf "add_edges_between_nodes(%s,%s,%s)"
-           (Types.show_node source_node) (Types.show_node target_node)
-           (String_utils.string_of_list (Types.show_stack_action) stack_actions)
-      )
-      (fun _ -> "Finished") @@
-    fun () ->
-    (* This recursive function creates the chain of single stack action edges
-       from the provided list of stack actions.  It consumes intermediate node
-       numbers as necessary to generate the edges, so it takes and returns this
-       value. *)
-    let rec mk_real_edges actions next_source =
-      match actions with
-      | [] ->
-        let edge =
-          { source = next_source
-          ; target = target_node
-          ; edge_action = Nop
-          }
-        in
-        [edge]
-      | [action] ->
-        let edge =
-          { source = next_source
-          ; target = target_node
-          ; edge_action = action
-          }
-        in
-        [edge]
-      | action::actions' ->
-        let target = Intermediate_node(target_node, actions') in
-        let edge =
-          { source = next_source
-          ; target = target
-          ; edge_action = action
-          }
-        in
-        let real_edges = mk_real_edges actions' target in
-        edge :: real_edges
+  let add_edge from_state stack_action_list to_state analysis =
+    let edge =
+      next_edge_in_sequence
+        (State_node from_state)
+        stack_action_list
+        (State_node to_state)
     in
-    (* Let's figure out which new single-action edges we will be adding. *)
-    let real_edges = mk_real_edges stack_actions source_node in
-    let analysis' =
-      add_node source_node @@ add_node target_node analysis
-    in
-    (* Log the result. *)
-    lazy_logger `trace @@
-    (fun () ->
-       Printf.sprintf "In add_edges_between_nodes(%s,%s,%s), generated edges: %s"
-         (Types.show_node source_node) (Types.show_node target_node)
-         (String_utils.string_of_list (Types.show_stack_action) stack_actions)
-         (String_utils.string_of_list Types.show_edge real_edges)
-    );
-    (* Now, let's add them. *)
-    real_edges
-    |> List.fold_left
-      (fun analysis'' real_edge ->
-         add_real_edge_and_close real_edge analysis'')
-      analysis'
-
-  (**
-     Adds an edge to this analysis.  Here, "edge" refers to the interface's
-     presentation of an edge structure.
-  *)
-  and add_edge source_state stack_action_list target_state analysis =
-    let source_node = State_node(source_state) in
-    let target_node = State_node(target_state) in
-    add_edges_between_nodes source_node target_node stack_action_list analysis
-
-  and add_untargeted_dynamic_pop_action source_state action analysis =
-    let source_node = State_node source_state in
-    if Structure.has_untargeted_dynamic_pop_action source_node action
-        analysis.reachability
-    then analysis
-    else
-      let analysis' =
-        { analysis with
-          reachability =
-            Structure.add_untargeted_dynamic_pop_action source_node action
-              analysis.reachability
-        }
-      in
-      (* Any existing pushes into the source of this pop action may generate
-         new edges.  Collect and add them. *)
-      analysis'.reachability
-      |> Structure.find_push_edges_by_target source_node
-      |> Enum.map
-        (fun (push_source_node, element) ->
-           Dph.perform_untargeted_dynamic_pop element action
-           |> Enum.map (fun x -> (push_source_node,x))
-        )
-      |> Enum.concat
-      |> Enum.fold
-        (fun analysis'' (push_source_node, (path, target_state)) ->
-           let target_node = State_node target_state in
-           add_edges_between_nodes push_source_node target_node path analysis'')
-        analysis'
-
-  (**
-     Adds a node to the analysis.  Specifically, adds all edges with that node
-     as a source that are returned by the analysis's edge functions.
-  *)
-  and add_node node analysis =
-    Logger_utils.lazy_bracket_log (lazy_logger `trace)
-      (fun _ ->
-         "add_node (" ^ show_node node ^ ")")
-      (fun _ -> "Finished") @@
-    fun () ->
-    if Node_set.mem node analysis.known_nodes then analysis else
-      let analysis' =
-        { analysis with
-          known_nodes = Node_set.add node analysis.known_nodes }
-      in
-      match node with
-      | Intermediate_node _ -> analysis'
-      | State_node state ->
-        let analysis'' =
-          analysis.edge_functions
-          |> List.enum
-          |> Enum.map (fun f -> f state)
-          |> Enum.concat
-          |> Enum.fold
-            (fun analysis_so_far (actions,target_state) ->
-               add_edge state actions target_state analysis_so_far)
-            analysis'
-        in
-        let analysis''' =
-          analysis.untargeted_dynamic_pop_action_functions
-          |> List.enum
-          |> Enum.map (fun f -> f state)
-          |> Enum.concat
-          |> Enum.fold
-            (fun analysis_so_far action ->
-               add_untargeted_dynamic_pop_action state action analysis_so_far)
-            analysis''
-        in
-        analysis'''
+    analysis |> add_work (Work.Introduce_edge edge)
   ;;
 
   let add_edge_function edge_function analysis =
-    Logger_utils.lazy_bracket_log (lazy_logger `trace)
-      (fun _ -> "add_edge_function (...)")
-      (fun _ -> "Finished") @@
-    fun () ->
-    let analysis' =
-      { analysis with edge_functions = edge_function::analysis.edge_functions }
+    (* First, we have to catch up on this edge function by calling it with every
+       state present in the analysis. *)
+    let work =
+      analysis.known_states
+      |> State_set.enum
+      |> Enum.map
+        (fun from_state ->
+           from_state
+           |> edge_function
+           |> Enum.map
+             (fun (actions,to_state) ->
+                let edge =
+                  next_edge_in_sequence
+                    (State_node from_state)
+                    actions
+                    (State_node to_state)
+                in
+                (* We know that the from_node has already been introduced. *)
+                Work.Introduce_edge edge
+             )
+        )
+      |> Enum.concat
     in
-    (* Of course, there may be nodes already in the graph which will respond to
-       this function.  Make sure to get edges for them. *)
-    analysis'.known_nodes
-    |> Node_set.enum
-    |> Enum.filter_map
-      (fun node ->
-         match node with
-         | State_node state -> Some state
-         | Intermediate_node _ -> None)
-    |> Enum.map
-      (fun source_state ->
-         edge_function source_state |> Enum.map (fun x -> (source_state, x)))
-    |> Enum.concat
-    |> Enum.fold
-      (fun analysis'' (source_state,(action_list,target_state)) ->
-         add_edge source_state action_list target_state analysis'')
-      analysis'
+    (* Now we add both the catch-up work (so the analysis is as if the edge
+       function was present all along) and the edge function (so it'll stay
+       in sync in the future). *)
+    { (add_works work analysis) with
+      edge_functions = edge_function :: analysis.edge_functions
+    }
   ;;
 
-  let add_untargeted_dynamic_pop_action_function fn analysis =
-    Logger_utils.lazy_bracket_log (lazy_logger `trace)
-      (fun _ -> "add_untargeted_dynamic_pop_action_function(...)")
-      (fun _ -> "Finished") @@
-    fun () ->
-    let analysis' =
-      { analysis with
-        untargeted_dynamic_pop_action_functions =
-          fn::analysis.untargeted_dynamic_pop_action_functions
-      }
+  let add_untargeted_dynamic_pop_action from_state pop_action analysis =
+    let from_node = State_node from_state in
+    analysis
+    |> add_work (Work.Introduce_untargeted_dynamic_pop(from_node, pop_action))
+  ;;
+
+  let add_untargeted_dynamic_pop_action_function pop_action_fn analysis =
+    (* First, we have to catch up on this function by calling it with every
+       state we know about. *)
+    let work =
+      analysis.known_states
+      |> State_set.enum
+      |> Enum.map
+        (fun from_state ->
+           from_state
+           |> pop_action_fn
+           |> Enum.map
+             (fun action ->
+                let from_node = State_node from_state in
+                Work.Introduce_untargeted_dynamic_pop(from_node, action)
+             )
+        )
+      |> Enum.concat
     in
-    (* There may be nodes already in the graph which need the pop actions from
-       this function.  Find them and add those actions. *)
-    analysis'.known_nodes
-    |> Node_set.enum
-    |> Enum.filter_map
-      (fun node ->
-         match node with
-         | State_node state -> Some state
-         | Intermediate_node _ -> None)
-    |> Enum.map
-      (fun source_state ->
-         fn source_state |> Enum.map (fun x -> (source_state, x)))
-    |> Enum.concat
-    |> Enum.fold
-      (fun analysis'' (source_state, action) ->
-         add_untargeted_dynamic_pop_action source_state action analysis'')
-      analysis'
+    (* Now we add both the catch-up work (so the analysis is as if the function
+       was present all along) and the function (so it'll stay in sync in the
+       future). *)
+    { (add_works work analysis) with
+      untargeted_dynamic_pop_action_functions =
+        pop_action_fn :: analysis.untargeted_dynamic_pop_action_functions
+    }
   ;;
 
   let add_start_state state stack_actions analysis =
-    Logger_utils.lazy_bracket_log (lazy_logger `trace)
-      (fun _ -> Printf.sprintf "add_start_state(%s,...)"
-          (pp_to_string Basis.pp_state state))
-      (fun _ -> "Finished") @@
-    fun () ->
     analysis
-    |> add_edges_between_nodes
-      (Intermediate_node(State_node(state), stack_actions))
-      (State_node(state))
-      stack_actions
+    |> add_work
+      (Work.Expand_node(Intermediate_node(State_node(state), stack_actions)))
   ;;
 
   let is_closed analysis =
@@ -572,8 +335,260 @@ struct
   ;;
 
   let closure_step analysis =
-    ignore analysis;
-    raise @@ Utils.Not_yet_implemented "closure_step"
+    let (new_work_collection, work_opt) =
+      Work_collection_impl.take analysis.work_collection
+    in
+    match work_opt with
+    | None -> analysis
+    | Some work ->
+      let analysis = { analysis with work_collection = new_work_collection } in
+      (* A utility function to add a node to a set *only if* it needs to be
+         expanded. *)
+      let expand_add node nodes_to_expand =
+        let entry =
+          Node_map.Exceptionless.find node analysis.node_awareness_map
+        in
+        if entry <> Some Expanded
+        then Node_set.add node nodes_to_expand
+        else nodes_to_expand
+      in
+      match work with
+      | Work.Expand_node node ->
+        begin
+          (* We're adding to the analysis a node that it does not contain. *)
+          match node with
+          | State_node(state) ->
+            (* We just need to introduce this node to all of the edge functions
+               that we have accumulated so far. *)
+            let work =
+              analysis.edge_functions
+              |> List.enum
+              |> Enum.map (fun f -> f state)
+              |> Enum.concat
+              |> Enum.map (fun (actions,to_state) ->
+                  let edge =
+                    next_edge_in_sequence
+                      (State_node state)
+                      actions
+                      (State_node to_state)
+                  in
+                  (* We know that the from_node has already been introduced. *)
+                  Work.Introduce_edge edge
+                )
+            in
+            { (add_works work analysis) with
+              known_states = analysis.known_states |> State_set.add state
+            ; node_awareness_map =
+                analysis.node_awareness_map
+                |> Node_map.add node Expanded
+            }
+          | Intermediate_node(target, actions) ->
+            (* The only edge implied by an intermediate node is the one that
+               moves along the action chain. *)
+            let work =
+              begin
+                match actions with
+                | [] ->
+                  Work.Introduce_edge(
+                    {source=node;target=target;edge_action=Nop})
+                | [action] ->
+                  Work.Introduce_edge(
+                    {source=node;target=target;edge_action=action})
+                | action::actions' ->
+                  Work.Introduce_edge(
+                    { source=node
+                    ; target=Intermediate_node(target, actions')
+                    ; edge_action=action})
+              end
+            in
+            (* We now have some work based upon the node to introduce.  We must
+               also mark the node as present. *)
+            { (add_work work analysis) with
+              node_awareness_map =
+                Node_map.add node Expanded analysis.node_awareness_map
+            }
+        end
+      | Work.Introduce_edge edge ->
+        let { source = from_node
+            ; target = to_node
+            ; edge_action = action
+            } = edge
+        in
+        let analysis' =
+          (* When an edge is introduced, all of the edges connecting to it should
+             be closed with it.  These new edges are introduced to the work queue
+             and drive the gradual expansion of closure.  It may also be necessary
+             to expand some nodes which have not yet been expanded. *)
+          let edge_work, nodes_to_expand =
+            match action with
+            | Nop ->
+              (* The only closure for nop edges is to find all pushes that lead
+                 into them and route them through the nop.  As this creates new
+                 push edges, the target should be expanded when at least one
+                 edge is created. *)
+              let work =
+                analysis.reachability
+                |> Structure.find_push_edges_by_target from_node
+                |> Enum.map
+                  (fun (from_node', element) ->
+                     Work.Introduce_edge(
+                       { source = from_node'
+                       ; target = to_node
+                       ; edge_action = Push element
+                       })
+                  )
+              in
+              if Enum.is_empty work
+              then (work, Node_set.empty)
+              else (work, expand_add to_node Node_set.empty)
+            | Push k ->
+              (* Any nop, pop, or popdyn edges at the target of this push can be
+                 closed.  Any new targets are candidates for expansion. *)
+              let nop_work_list, nop_expand_set =
+                analysis.reachability
+                |> Structure.find_nop_edges_by_source to_node
+                |> Enum.fold
+                  (fun (work_list, expand_set) to_node' ->
+                     let work =
+                       Work.Introduce_edge(
+                         { source = from_node
+                         ; target = to_node'
+                         ; edge_action = Push k
+                         })
+                     in
+                     (work::work_list, expand_add to_node' expand_set)
+                  )
+                  ([], Node_set.empty)
+              in
+              let pop_work_list, pop_expand_set =
+                analysis.reachability
+                |> Structure.find_pop_edges_by_source to_node
+                |> Enum.filter
+                  (fun (_, element) -> equal_stack_element k element)
+                |> Enum.fold
+                  (fun (work_list, expand_set) (to_node', _) ->
+                     let work =
+                       Work.Introduce_edge(
+                         { source = from_node
+                         ; target = to_node'
+                         ; edge_action = Nop
+                         })
+                     in
+                     (work::work_list, expand_add to_node' expand_set)
+                  )
+                  ([], Node_set.empty)
+              in
+              let popdyn_work_list, popdyn_expand_set =
+                analysis.reachability
+                |> Structure.find_targeted_dynamic_pop_edges_by_source to_node
+                |> Enum.fold
+                  (fun (work_list, expand_set) (to_node', action) ->
+                     Dph.perform_targeted_dynamic_pop k action
+                     |> Enum.fold
+                       (fun (work_list, expand_set) stack_actions ->
+                          let edge =
+                            next_edge_in_sequence
+                              from_node stack_actions to_node'
+                          in
+                          let work = Work.Introduce_edge edge in
+                          (work::work_list, expand_add to_node' expand_set)
+                       ) (work_list,expand_set)
+                  ) ([],Node_set.empty)
+              in
+              ( Enum.concat @@ List.enum
+                  [ List.enum nop_work_list
+                  ; List.enum pop_work_list
+                  ; List.enum popdyn_work_list
+                  ]
+              , Node_set.union popdyn_expand_set @@
+                Node_set.union nop_expand_set pop_expand_set
+              )
+            | Pop k ->
+              (* Pop edges can only close with the push edges that precede them.
+                 The target of these new edges is a candidate for expansion. *)
+              let work =
+                analysis.reachability
+                |> Structure.find_push_edges_by_target from_node
+                |> Enum.filter_map
+                  (fun (from_node', element) ->
+                     if equal_stack_element element k
+                     then Some(
+                         Work.Introduce_edge(
+                           { source = from_node'
+                           ; target = to_node
+                           ; edge_action = Nop
+                           }))
+                     else None
+                  )
+              in
+              if Enum.is_empty work
+              then (work, Node_set.empty)
+              else (work, expand_add to_node Node_set.empty)
+            | Pop_dynamic_targeted action ->
+              (* Dynamic pop edges can only close with push edges that precede
+                 them.  The target of these new edges is a candidate for
+                 expansion. *)
+              let (work_list, to_expand) =
+                analysis.reachability
+                |> Structure.find_push_edges_by_target from_node
+                |> Enum.fold
+                  (fun (work_list, expand_set) (from_node', element) ->
+                     Dph.perform_targeted_dynamic_pop element action
+                     |> Enum.fold
+                       (fun (work_list, expand_set) stack_actions ->
+                          let edge =
+                            next_edge_in_sequence
+                              from_node' stack_actions to_node
+                          in
+                          let work = Work.Introduce_edge edge in
+                          (work::work_list, expand_add to_node expand_set)
+                       ) (work_list,expand_set)
+                  ) ([],Node_set.empty)
+              in (List.enum work_list, to_expand)
+          in
+          let expand_work = nodes_to_expand
+                            |> Node_set.enum
+                            |> Enum.map (fun node -> Work.Expand_node node)
+          in
+          add_works (Enum.append edge_work expand_work) analysis
+        in
+        { analysis' with
+          reachability = analysis'.reachability |> Structure.add_edge edge
+        }
+      | Work.Introduce_untargeted_dynamic_pop(from_node,action) ->
+        (* Untargeted dynamic pops can only close with the push edges that
+           reach them.  Any targets of the resulting edges are candidates for
+           expansion. *)
+        let analysis' =
+          let (work_list, nodes_to_expand) =
+            analysis.reachability
+            |> Structure.find_push_edges_by_target from_node
+            |> Enum.fold
+              (fun (work_list, expand_set) (from_node', element) ->
+                 Dph.perform_untargeted_dynamic_pop element action
+                 |> Enum.fold
+                   (fun (work_list, expand_set) (stack_action_list, to_state) ->
+                      let to_node = State_node(to_state) in
+                      let edge =
+                        next_edge_in_sequence
+                          from_node' stack_action_list to_node
+                      in
+                      let work = Work.Introduce_edge edge in
+                      (work::work_list, expand_add to_node expand_set)
+                   ) (work_list, expand_set)
+              ) ([],Node_set.empty)
+          in
+          let expand_work = nodes_to_expand
+                            |> Node_set.enum
+                            |> Enum.map (fun node -> Work.Expand_node node)
+          in
+          add_works (Enum.append (List.enum work_list) expand_work) analysis
+        in
+        { analysis' with
+          reachability = analysis'.reachability
+                         |> Structure.add_untargeted_dynamic_pop_action
+                           from_node action
+        }
   ;;
 
   let rec fully_close analysis =
@@ -584,11 +599,12 @@ struct
 
   let get_reachable_states state stack_actions analysis =
     let node = Intermediate_node(State_node(state), stack_actions) in
-    if Node_set.mem node analysis.known_nodes
+    if Node_map.mem node analysis.node_awareness_map
     then
       (*
         If a state is reachable by empty stack from the given starting state,
-        then there will be a nop edge to it.  It's that simple by this point.
+        then there will be a nop edge to it.  It's that simple once closure
+        is finished.
       *)
       analysis.reachability
       |> Structure.find_nop_edges_by_source node

--- a/src/pds-reachability/pds_reachability_analysis.ml
+++ b/src/pds-reachability/pds_reachability_analysis.ml
@@ -411,7 +411,7 @@ struct
           | State_node(state) ->
             (* We just need to introduce this node to all of the edge functions
                that we have accumulated so far. *)
-            let work =
+            let edge_work =
               analysis.edge_functions
               |> List.enum
               |> Enum.map (fun f -> f state)
@@ -427,7 +427,17 @@ struct
                   Work.Introduce_edge edge
                 )
             in
-            { (add_works work analysis) with
+            let popdynu_work =
+              analysis.untargeted_dynamic_pop_action_functions
+              |> List.enum
+              |> Enum.map (fun f -> f state)
+              |> Enum.concat
+              |> Enum.map
+                (fun action ->
+                  Work.Introduce_untargeted_dynamic_pop(node, action)
+                )
+            in
+            { (analysis |> add_works edge_work |> add_works popdynu_work) with
               known_states = analysis.known_states |> State_set.add state
             ; node_awareness_map =
                 analysis.node_awareness_map

--- a/src/pds-reachability/pds_reachability_analysis.ml
+++ b/src/pds-reachability/pds_reachability_analysis.ml
@@ -738,6 +738,11 @@ struct
   ;;
 
   let get_reachable_states state stack_actions analysis =
+    lazy_logger `debug (fun () ->
+        let (nodes,edges) = get_size analysis in
+        Printf.sprintf "get_reachable_states: analysis has %d nodes and %d edges"
+          nodes edges
+      );
     let node = Intermediate_node(State_node(state), stack_actions) in
     if Node_set.mem node analysis.start_nodes
     then

--- a/src/pds-reachability/pds_reachability_structure.ml
+++ b/src/pds-reachability/pds_reachability_structure.ml
@@ -97,7 +97,7 @@ module Make
       and type stack_element = Basis.stack_element
       and type targeted_dynamic_pop_action = Dph.targeted_dynamic_pop_action
       and type untargeted_dynamic_pop_action = Dph.untargeted_dynamic_pop_action
-      )
+    )
   : Structure
     with type stack_element = Basis.stack_element
      and type edge = Types.edge

--- a/src/pds-reachability/pds_reachability_types.ml
+++ b/src/pds-reachability/pds_reachability_types.ml
@@ -11,11 +11,18 @@ sig
   (** The type of states in the PDS. *)
   type state
 
+  val equal_state : state -> state -> bool;;
+
   (** The type of stack elements in the PDS. *)
   type stack_element
 
+  val equal_stack_element : stack_element -> stack_element -> bool;;
+
   (** The type of targeted dynamic pop actions in the PDS. *)
   type targeted_dynamic_pop_action
+
+  val equal_targeted_dynamic_pop_action :
+    targeted_dynamic_pop_action -> targeted_dynamic_pop_action -> bool;;
 
   (** The type of untargeted dynamic pop actions in the PDS. *)
   type untargeted_dynamic_pop_action
@@ -55,6 +62,9 @@ sig
     ; edge_action : stack_action
     };;
 
+  val equal_edge : edge -> edge -> bool
+  val compare_edge : edge -> edge -> int
+
   (** Pretty-printing for edges. *)
   val pp_edge : edge pretty_printer
   val show_edge : edge -> string
@@ -64,18 +74,18 @@ sig
 end;;
 
 module Make
-        (Basis : Pds_reachability_basis.Basis)
-        (Dph : Pds_reachability_types_stack.Dynamic_pop_handler
-            with type stack_element = Basis.stack_element
-             and type state = Basis.state
-        )
+    (Basis : Pds_reachability_basis.Basis)
+    (Dph : Pds_reachability_types_stack.Dynamic_pop_handler
+     with type stack_element = Basis.stack_element
+      and type state = Basis.state
+    )
   : Types with type stack_element = Basis.stack_element
            and type state = Basis.state
            and type targeted_dynamic_pop_action =
-                      Dph.targeted_dynamic_pop_action
+                 Dph.targeted_dynamic_pop_action
            and type untargeted_dynamic_pop_action =
-                      Dph.untargeted_dynamic_pop_action
-  =
+                 Dph.untargeted_dynamic_pop_action
+=
 struct
   type state = Basis.state;;
   type stack_element = Basis.stack_element;;
@@ -84,6 +94,17 @@ struct
 
   let compare_state = Basis.State_ord.compare;;
   let compare_stack_element = Basis.Stack_element_ord.compare;;
+  let equal_state s s' = Basis.State_ord.compare s s' = 0;;
+  let equal_stack_element e e' =
+    Basis.Stack_element_ord.compare e e' = 0
+  ;;
+  let equal_targeted_dynamic_pop_action a a' =
+    Dph.compare_targeted_dynamic_pop_action a a' = 0
+  ;;
+  let equal_stack_action =
+    Pds_reachability_types_stack.equal_pds_stack_action
+      equal_stack_element equal_targeted_dynamic_pop_action
+  ;;
   open Basis;;
   open Dph;;
   type stack_action =
@@ -105,7 +126,7 @@ struct
   type node =
     | State_node of state
     | Intermediate_node of node * stack_action list
-    [@@deriving ord, show]
+    [@@deriving eq, ord, show]
   ;;
 
   let rec ppa_node formatter node =
@@ -121,7 +142,7 @@ struct
     ; target : node
     ; edge_action : stack_action
     }
-    [@@deriving show]
+    [@@deriving eq, ord, show]
   ;;
 
   let ppa_edge formatter edge =

--- a/src/pds-reachability/pds_reachability_types.ml
+++ b/src/pds-reachability/pds_reachability_types.ml
@@ -27,6 +27,13 @@ sig
   (** The type of untargeted dynamic pop actions in the PDS. *)
   type untargeted_dynamic_pop_action
 
+  val equal_untargeted_dynamic_pop_action :
+    untargeted_dynamic_pop_action -> untargeted_dynamic_pop_action -> bool;;
+  val compare_untargeted_dynamic_pop_action :
+    untargeted_dynamic_pop_action -> untargeted_dynamic_pop_action -> int;;
+  val pp_untargeted_dynamic_pop_action :
+    Format.formatter -> untargeted_dynamic_pop_action -> unit;;
+
   (** Stack actions which may be performed in the PDS. *)
   type stack_action =
     ( stack_element
@@ -47,6 +54,7 @@ sig
 
   (** A comparison for nodes. *)
   val compare_node : node -> node -> int
+  val equal_node : node -> node -> bool
 
   (** Pretty-printing for nodes. *)
   val pp_node : node pretty_printer
@@ -100,6 +108,15 @@ struct
   ;;
   let equal_targeted_dynamic_pop_action a a' =
     Dph.compare_targeted_dynamic_pop_action a a' = 0
+  ;;
+  let equal_untargeted_dynamic_pop_action a a' =
+    Dph.compare_untargeted_dynamic_pop_action a a' = 0
+  ;;
+  let compare_untargeted_dynamic_pop_action =
+    Dph.compare_untargeted_dynamic_pop_action
+  ;;
+  let pp_untargeted_dynamic_pop_action =
+    Dph.pp_untargeted_dynamic_pop_action
   ;;
   let equal_stack_action =
     Pds_reachability_types_stack.equal_pds_stack_action

--- a/src/pds-reachability/pds_reachability_types_stack.ml
+++ b/src/pds-reachability/pds_reachability_types_stack.ml
@@ -20,7 +20,7 @@ type ( 'stack_element
       fixed; they vary depending upon the stack element which is provided.
       This operation may also be non-deterministic, providing several
       chains of operations to the same target. *)
-  [@@deriving ord, show]
+  [@@deriving eq, ord, show]
 ;;
 
 (** The type of a module which resolves dynamic pops. *)

--- a/src/pds-reachability/pds_reachability_work.ml
+++ b/src/pds-reachability/pds_reachability_work.ml
@@ -1,0 +1,58 @@
+open Pds_reachability_basis;;
+open Pds_reachability_types;;
+
+(** This module specifies the type used to describe work in a PDS reachability
+    analysis as well as the interface for managing a pending work collection. *)
+module type Work_type =
+sig
+  (** The basis module for the PDS reachability analysis. *)
+  module B : Basis;;
+
+  (** The types module for the PDS reachability analysis. *)
+  module T : Types
+    with type state = B.state
+     and type stack_element = B.stack_element;;
+
+  (** The type of a work unit. *)
+  type work =
+    | Expand_state of T.state
+    | Introduce_edge of T.edge
+  ;;
+
+  (** An equality test for work unit. *)
+  val equal_work : work -> work -> bool
+
+  (** A comparator for work units. *)
+  val compare_work : work -> work -> int
+
+  (** A pretty-printer for work units. *)
+  val pp_work : Format.formatter -> work -> unit
+
+  (** A conversion from work units to strings. *)
+  val show_work : work -> string
+end;;
+
+module Make
+    (B : Basis)
+    (T : Types with type state = B.state
+                and type stack_element = B.stack_element)
+  : Work_type with module B = B
+               and module T = T
+=
+struct
+  module B = B;;
+  module T = T;;
+  type t_state = T.state;;
+  type t_edge = T.edge;;
+  let equal_t_state = T.equal_state;;
+  let equal_t_edge = T.equal_edge;;
+  let compare_t_state = B.State_ord.compare;;
+  let compare_t_edge = T.compare_edge;;
+  let pp_t_state = B.pp_state;;
+  let pp_t_edge = T.pp_edge;;
+  type work =
+    | Expand_state of t_state
+    | Introduce_edge of t_edge
+    [@@deriving eq, ord, show]
+  ;;
+end;;

--- a/src/pds-reachability/pds_reachability_work.ml
+++ b/src/pds-reachability/pds_reachability_work.ml
@@ -15,8 +15,10 @@ sig
 
   (** The type of a work unit. *)
   type work =
-    | Expand_state of T.state
+    | Expand_node of T.node
     | Introduce_edge of T.edge
+    | Introduce_untargeted_dynamic_pop of
+        T.node * T.untargeted_dynamic_pop_action
   ;;
 
   (** An equality test for work unit. *)
@@ -42,17 +44,19 @@ module Make
 struct
   module B = B;;
   module T = T;;
-  type t_state = T.state;;
+  type t_node = T.node;;
   type t_edge = T.edge;;
-  let equal_t_state = T.equal_state;;
+  let equal_t_node = T.equal_node;;
   let equal_t_edge = T.equal_edge;;
-  let compare_t_state = B.State_ord.compare;;
+  let compare_t_node = T.compare_node;;
   let compare_t_edge = T.compare_edge;;
-  let pp_t_state = B.pp_state;;
+  let pp_t_node = T.pp_node;;
   let pp_t_edge = T.pp_edge;;
   type work =
-    | Expand_state of t_state
+    | Expand_node of t_node
     | Introduce_edge of t_edge
+    | Introduce_untargeted_dynamic_pop of
+        T.node * T.untargeted_dynamic_pop_action
     [@@deriving eq, ord, show]
   ;;
 end;;

--- a/src/pds-reachability/pds_reachability_work_collection.ml
+++ b/src/pds-reachability/pds_reachability_work_collection.ml
@@ -1,0 +1,53 @@
+open Pds_reachability_work;;
+
+(** This module type describes the interface for a work collection. *)
+module type Work_collection =
+sig
+  (* The module defining the work type. *)
+  module W : Work_type
+
+  (** The type of a work collection. *)
+  type work_collection
+
+  (** An equality test for work collections. *)
+  val equal_work_collection : work_collection -> work_collection -> bool
+
+  (** A comparator for work collections. *)
+  val compare_work_collection : work_collection -> work_collection -> int
+
+  (** A pretty-printer for work collections. *)
+  val pp_work_collection : Format.formatter -> work_collection -> unit
+
+  (** A conversion from work collections to strings. *)
+  val show_work_collection : work_collection -> string
+
+
+  (** An empty work collection. *)
+  val empty : work_collection
+
+  (** Adds a work unit to a work collection. *)
+  val offer : W.work -> work_collection -> work_collection
+
+  (** Extracts a work unit from a work collection.  The only guaratees made by
+      this routine are as follows:
+
+      - Each offered work element can be taken exactly once.
+      - A work element is always provided unless the collection is empty.
+
+      In particular, there are no guarantees made about the order in which the
+      offered elements are taken.
+  *)
+  val take : work_collection -> work_collection * W.work option
+
+  (** Determines if a work collection is empty. *)
+  val is_empty : work_collection -> bool
+
+  (** Determines the number of elements to be taken from a given work
+      collection. *)
+  val size : work_collection -> int
+end;;
+
+(** This module type describes a work collection implementation.  Such an
+    implementation will, given a work type, produce a work collection. *)
+module type Work_collection_template =
+  functor (W : Work_type) -> Work_collection with module W = W

--- a/src/pds-reachability/pds_reachability_work_collection_templates.ml
+++ b/src/pds-reachability/pds_reachability_work_collection_templates.ml
@@ -1,0 +1,21 @@
+open Batteries;;
+
+open Pds_reachability_work;;
+open Pds_reachability_work_collection;;
+
+module Work_stack : Work_collection_template = functor(W : Work_type) ->
+struct
+  module W = W;;
+  type work_collection = W.work list
+    [@@deriving eq, ord, show]
+  ;;
+  let empty = [];;
+  let offer work coll = work::coll;;
+  let take coll =
+    match coll with
+    | [] -> ([], None)
+    | h::t -> (t, Some h)
+  ;;
+  let is_empty coll = (List.is_empty coll);;
+  let size = List.length;;
+end;;

--- a/src/toploop-utils/toploop_ddpa.ml
+++ b/src/toploop-utils/toploop_ddpa.ml
@@ -67,8 +67,8 @@ struct
 
   module C = A.C;;
 
-  let create_analysis ?logging_prefix:(pfx=None) expr =
-    let a = A.create_initial_analysis ~logging_prefix:pfx expr in
+  let create_analysis expr =
+    let a = A.create_initial_analysis expr in
     { aref = ref @@ A.perform_full_closure a
     ; expression = expr
     }

--- a/src/toploop-utils/toploop_ddpa_types.ml
+++ b/src/toploop-utils/toploop_ddpa_types.ml
@@ -73,7 +73,7 @@ module type DDPA = sig
 
   module C : Context_stack;;
 
-  val create_analysis : ?logging_prefix:string option -> expr -> analysis
+  val create_analysis : expr -> analysis
 
   val values_of_variable_from :
     var -> annotated_clause -> analysis -> Abs_filtered_value_set.t

--- a/src/toploop/toploop.ml
+++ b/src/toploop/toploop.ml
@@ -57,9 +57,7 @@ let toploop_operate conf e =
               | None -> ();
             end;
             (* Create the analysis.  The wrapper performs full closure on it. *)
-            let analysis =
-              TLA.create_analysis ~logging_prefix: (Some "_toploop") e
-            in
+            let analysis = TLA.create_analysis e in
             (* Determine if it is consistent. *)
             let inconsistencies =
               if conf.topconf_disable_inconsistency_check

--- a/src/utils/pp_utils.ml
+++ b/src/utils/pp_utils.ml
@@ -56,6 +56,10 @@ let pp_map pp_k pp_v enum formatter dict =
   pp_concat_sep_delim "{" "}" "," pp_kv_pair formatter @@ enum dict
 ;;
 
+let pp_set pp_el enum formatter set =
+  pp_concat_sep_delim "{" "}" "," pp_el formatter @@ enum set
+;;
+
 let pp_to_string pp x =
   let buffer = Buffer.create 80 in
   let formatter = formatter_of_buffer buffer in

--- a/src/utils/pp_utils.mli
+++ b/src/utils/pp_utils.mli
@@ -87,9 +87,17 @@ val pp_list : 'a pretty_printer -> formatter -> 'a list -> unit
     - The enumeration function for the dictionary.
     - The formatter to use.
     - The dictionary.
- *)
+*)
 val pp_map : 'k pretty_printer -> 'v pretty_printer ->
   ('d -> ('k * 'v) Enum.t) -> formatter -> 'd -> unit
+
+(** Pretty-prints a set data structure.  The arguments are:
+    - The pretty-printing function for a value.
+    - The enumeration function for the set.
+    - The formatter to use.
+    - The dictionary.
+*)
+val pp_set : 'a pretty_printer -> ('s -> 'a Enum.t) -> formatter -> 's -> unit
 
 (** Given a pretty printer and an object, generates a string for them. *)
 val pp_to_string : 'a pretty_printer -> 'a -> string

--- a/test/test_reachability.ml
+++ b/test/test_reachability.ml
@@ -114,7 +114,7 @@ module Test_reachability =
 let immediate_reachability_test =
   "immediate_reachability_test" >:: fun _ ->
     let analysis =
-      Test_reachability.empty ()
+      Test_reachability.empty
       |> Test_reachability.add_edge 0 [Pop 'a'] 1
       |> Test_reachability.add_start_state 0 [Push 'a']
     in
@@ -125,7 +125,7 @@ let immediate_reachability_test =
 let immediate_non_reachable_test =
   "immediate_non_reachable_test" >:: fun _ ->
     let analysis =
-      Test_reachability.empty ()
+      Test_reachability.empty
       |> Test_reachability.add_edge 0 [Pop 'b'] 1
       |> Test_reachability.add_start_state 0 [Push 'a']
     in
@@ -136,7 +136,7 @@ let immediate_non_reachable_test =
 let two_step_reachability_test =
   "two_step_reachability_test" >:: fun _ ->
     let analysis =
-      Test_reachability.empty ()
+      Test_reachability.empty
       |> Test_reachability.add_edge 0 [Pop 'a'; Push 'b'] 1
       |> Test_reachability.add_edge 1 [Pop 'b'] 2
       |> Test_reachability.add_start_state 0 [Push 'a']
@@ -151,7 +151,7 @@ let two_step_reachability_test =
 let cycle_reachability_test =
   "cycle_reachability_test" >:: fun _ ->
     let analysis =
-      Test_reachability.empty ()
+      Test_reachability.empty
       |> Test_reachability.add_edge 0 [Push 'b'] 0
       |> Test_reachability.add_edge 0 [Push 'c'] 1
       |> Test_reachability.add_edge 1 [Pop 'c'] 1
@@ -169,7 +169,7 @@ let cycle_reachability_test =
 let edge_function_reachability_test =
   "edge_function_reachability_test" >:: fun _ ->
     let analysis =
-      Test_reachability.empty ()
+      Test_reachability.empty
       |> Test_reachability.add_edge_function
           (fun state ->
             if state >= 50 then Enum.empty () else
@@ -188,7 +188,7 @@ let edge_function_reachability_test =
 let nondeterminism_reachability_test =
   "nondeterminism_reachability_test" >:: fun _ ->
     let analysis =
-      Test_reachability.empty ()
+      Test_reachability.empty
       |> Test_reachability.add_edge 0 [Pop 'a'] 1
       |> Test_reachability.add_edge 0 [Pop 'a'] 2
       |> Test_reachability.add_start_state 0 [Push 'a']
@@ -204,7 +204,7 @@ let targeted_dynamic_pop_reachability_test =
   "targeted_dynamic_pop_reachability_test" >:: fun _ ->
     (* The following function dynamically duplicates an element on the stack. *)
     let analysis =
-      Test_reachability.empty ()
+      Test_reachability.empty
       |> Test_reachability.add_edge 0
           [Pop_dynamic_targeted Test_dph.Double_push] 1
       |> Test_reachability.add_edge 1 [Pop 'a'; Pop 'a'] 2
@@ -222,7 +222,7 @@ let targeted_dynamic_pop_nondeterminism_reachability_test =
   "targeted_dynamic_pop_nondeterminism_reachability_test" >:: fun _ ->
     let dyn = Pop_dynamic_targeted Test_dph.Consume_identical_1_of_2 in
     let analysis =
-      Test_reachability.empty ()
+      Test_reachability.empty
       |> Test_reachability.add_edge 0 [Push 'b'; Push 'c'] 1
       |> Test_reachability.add_edge 1 [dyn] 2
       |> Test_reachability.add_edge 2 [Pop 'a'] 3
@@ -243,7 +243,7 @@ let targeted_dynamic_pop_nondeterminism_reachability_test =
 let untargeted_dynamic_pop_reachability_test =
   "untargeted_dynamic_pop_reachability_test" >:: fun _ ->
     let analysis =
-      Test_reachability.empty ()
+      Test_reachability.empty
       |> Test_reachability.add_edge 0 [Push 'a'] 1
       |> Test_reachability.add_untargeted_dynamic_pop_action
           1 (Test_dph.Target_condition_on_element_is_A(2,3))
@@ -309,7 +309,7 @@ let untargeted_dynamic_pop_function_reachability_test =
       else Enum.empty ()
     in
     let analysis =
-      Test_reachability.empty ()
+      Test_reachability.empty
       |> Test_reachability.add_edge 0 [Push 'a'; Push 'b'; Push 'b'] 1
       |> Test_reachability.add_edge 0 [Push 'a'; Push 'a'; Push 'a'] 1
       |> Test_reachability.add_edge 0 [Push 'b'; Push 'b'] 1
@@ -334,7 +334,7 @@ let untargeted_dynamic_pop_function_reachability_test =
 let targeted_dynamic_pop_chain_test =
   "targeted_dynamic_pop_chain_test" >:: fun _ ->
     let analysis =
-      Test_reachability.empty ()
+      Test_reachability.empty
       |> Test_reachability.add_edge 0
           [Pop_dynamic_targeted(
             Test_dph.Chain_two_push_1_of_2('a','b')); Push 'c'] 1

--- a/test/test_reachability.ml
+++ b/test/test_reachability.ml
@@ -117,6 +117,7 @@ let immediate_reachability_test =
       Test_reachability.empty
       |> Test_reachability.add_edge 0 [Pop 'a'] 1
       |> Test_reachability.add_start_state 0 [Push 'a']
+      |> Test_reachability.fully_close
     in
     let states = Test_reachability.get_reachable_states 0 [Push 'a'] analysis in
     assert_equal (List.of_enum states) [1]
@@ -128,6 +129,7 @@ let immediate_non_reachable_test =
       Test_reachability.empty
       |> Test_reachability.add_edge 0 [Pop 'b'] 1
       |> Test_reachability.add_start_state 0 [Push 'a']
+      |> Test_reachability.fully_close
     in
     let states = Test_reachability.get_reachable_states 0 [Push 'a'] analysis in
     assert_equal (List.of_enum states) []
@@ -140,6 +142,7 @@ let two_step_reachability_test =
       |> Test_reachability.add_edge 0 [Pop 'a'; Push 'b'] 1
       |> Test_reachability.add_edge 1 [Pop 'b'] 2
       |> Test_reachability.add_start_state 0 [Push 'a']
+      |> Test_reachability.fully_close
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
@@ -158,6 +161,7 @@ let cycle_reachability_test =
       |> Test_reachability.add_edge 1 [Pop 'b'] 1
       |> Test_reachability.add_edge 1 [Pop 'a'] 2
       |> Test_reachability.add_start_state 0 [Push 'a']
+      |> Test_reachability.fully_close
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
@@ -177,6 +181,7 @@ let edge_function_reachability_test =
       |> Test_reachability.add_edge 50 [Pop 'b'] 50
       |> Test_reachability.add_edge 50 [Pop 'a'] 51
       |> Test_reachability.add_start_state 0 [Push 'a']
+      |> Test_reachability.fully_close
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
@@ -192,6 +197,7 @@ let nondeterminism_reachability_test =
       |> Test_reachability.add_edge 0 [Pop 'a'] 1
       |> Test_reachability.add_edge 0 [Pop 'a'] 2
       |> Test_reachability.add_start_state 0 [Push 'a']
+      |> Test_reachability.fully_close
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
@@ -210,6 +216,7 @@ let targeted_dynamic_pop_reachability_test =
       |> Test_reachability.add_edge 1 [Pop 'a'; Pop 'a'] 2
       |> Test_reachability.add_edge 1 [Pop 'a'] 3
       |> Test_reachability.add_start_state 0 [Push 'a']
+      |> Test_reachability.fully_close
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
@@ -232,6 +239,7 @@ let targeted_dynamic_pop_nondeterminism_reachability_test =
       |> Test_reachability.add_edge 0 [Push 'y'; Push 'y'] 7
       |> Test_reachability.add_edge 7 [dyn; Pop 'a'] 8
       |> Test_reachability.add_start_state 0 [Push 'a']
+      |> Test_reachability.fully_close
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
@@ -261,6 +269,7 @@ let untargeted_dynamic_pop_reachability_test =
       |> Test_reachability.add_edge 22 [Pop 'q'] 28
       |> Test_reachability.add_edge 23 [Pop 'q'] 29
       |> Test_reachability.add_start_state 0 [Push 'q']
+      |> Test_reachability.fully_close
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
@@ -318,6 +327,7 @@ let untargeted_dynamic_pop_function_reachability_test =
       |> Test_reachability.add_untargeted_dynamic_pop_action_function
           untargeted_dynamic_pop_action_fn
       |> Test_reachability.add_start_state 0 [Push 'q']
+      |> Test_reachability.fully_close
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
@@ -340,6 +350,7 @@ let targeted_dynamic_pop_chain_test =
             Test_dph.Chain_two_push_1_of_2('a','b')); Push 'c'] 1
       |> Test_reachability.add_edge 1 [Pop 'c'; Pop 'b'; Pop 'a'; Pop 'x'] 2
       |> Test_reachability.add_start_state 0 [Push 'x']
+      |> Test_reachability.fully_close
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^

--- a/test/test_reachability.ml
+++ b/test/test_reachability.ml
@@ -1,6 +1,6 @@
 (**
-  This test module performs a series of operations to test the PDA reachability
-  functionality in the Odefa analysis library.
+   This test module performs a series of operations to test the PDA reachability
+   functionality in the Odefa analysis library.
 *)
 
 open Batteries;;
@@ -80,20 +80,20 @@ struct
     match action with
     | Double_push -> Enum.singleton [Push(element);Push(element)]
     | Consume_identical_1_of_2 -> Enum.singleton
-        [Pop_dynamic_targeted(Consume_identical_2_of_2 element)]
+                                    [Pop_dynamic_targeted(Consume_identical_2_of_2 element)]
     | Consume_identical_2_of_2 element' ->
-        if Test_stack_element_ord.compare element element' == 0
-        then Enum.singleton []
-        else Enum.empty ()
+      if Test_stack_element_ord.compare element element' == 0
+      then Enum.singleton []
+      else Enum.empty ()
     | Chain_two_push_1_of_2(k1,k2) ->
-        Enum.singleton
-          [ Pop_dynamic_targeted(Chain_two_push_2_of_2(k2))
-          ; Push(k1)
-          ; Push(element) ]
+      Enum.singleton
+        [ Pop_dynamic_targeted(Chain_two_push_2_of_2(k2))
+        ; Push(k1)
+        ; Push(element) ]
     | Chain_two_push_2_of_2 k ->
-        Enum.singleton
-          [ Push(k)
-          ; Push(element) ]
+      Enum.singleton
+        [ Push(k)
+        ; Push(element) ]
   ;;
   let perform_untargeted_dynamic_pop element action =
     match action with
@@ -146,7 +146,7 @@ let two_step_reachability_test =
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
-        String_utils.indent 2 (Test_reachability.show_analysis analysis));
+                 String_utils.indent 2 (Test_reachability.show_analysis analysis));
     let states = Test_reachability.get_reachable_states 0 [Push 'a'] analysis in
     assert_equal (List.of_enum states) [2]
 ;;
@@ -165,7 +165,7 @@ let cycle_reachability_test =
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
-        String_utils.indent 2 (Test_reachability.show_analysis analysis));
+                 String_utils.indent 2 (Test_reachability.show_analysis analysis));
     let states = Test_reachability.get_reachable_states 0 [Push 'a'] analysis in
     assert_equal (List.of_enum states) [2]
 ;;
@@ -175,9 +175,9 @@ let edge_function_reachability_test =
     let analysis =
       Test_reachability.empty
       |> Test_reachability.add_edge_function
-          (fun state ->
-            if state >= 50 then Enum.empty () else
-              Enum.singleton @@ ([Push 'b'], state + 1))
+        (fun state ->
+           if state >= 50 then Enum.empty () else
+             Enum.singleton @@ ([Push 'b'], state + 1))
       |> Test_reachability.add_edge 50 [Pop 'b'] 50
       |> Test_reachability.add_edge 50 [Pop 'a'] 51
       |> Test_reachability.add_start_state 0 [Push 'a']
@@ -185,7 +185,7 @@ let edge_function_reachability_test =
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
-        String_utils.indent 2 (Test_reachability.show_analysis analysis));
+                 String_utils.indent 2 (Test_reachability.show_analysis analysis));
     let states = Test_reachability.get_reachable_states 0 [Push 'a'] analysis in
     assert_equal (List.of_enum states) [51]
 ;;
@@ -201,7 +201,7 @@ let nondeterminism_reachability_test =
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
-        String_utils.indent 2 (Test_reachability.show_analysis analysis));
+                 String_utils.indent 2 (Test_reachability.show_analysis analysis));
     let states = Test_reachability.get_reachable_states 0 [Push 'a'] analysis in
     assert_equal (List.sort compare @@ List.of_enum states) [1;2]
 ;;
@@ -212,7 +212,7 @@ let targeted_dynamic_pop_reachability_test =
     let analysis =
       Test_reachability.empty
       |> Test_reachability.add_edge 0
-          [Pop_dynamic_targeted Test_dph.Double_push] 1
+        [Pop_dynamic_targeted Test_dph.Double_push] 1
       |> Test_reachability.add_edge 1 [Pop 'a'; Pop 'a'] 2
       |> Test_reachability.add_edge 1 [Pop 'a'] 3
       |> Test_reachability.add_start_state 0 [Push 'a']
@@ -220,7 +220,7 @@ let targeted_dynamic_pop_reachability_test =
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
-        String_utils.indent 2 (Test_reachability.show_analysis analysis));
+                 String_utils.indent 2 (Test_reachability.show_analysis analysis));
     let states = Test_reachability.get_reachable_states 0 [Push 'a'] analysis in
     assert_equal (List.sort compare @@ List.of_enum states) [2]
 ;;
@@ -243,7 +243,7 @@ let targeted_dynamic_pop_nondeterminism_reachability_test =
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
-        String_utils.indent 2 (Test_reachability.show_analysis analysis));
+                 String_utils.indent 2 (Test_reachability.show_analysis analysis));
     let states = Test_reachability.get_reachable_states 0 [Push 'a'] analysis in
     assert_equal (List.sort compare @@ List.of_enum states) [6;8]
 ;;
@@ -254,18 +254,18 @@ let untargeted_dynamic_pop_reachability_test =
       Test_reachability.empty
       |> Test_reachability.add_edge 0 [Push 'a'] 1
       |> Test_reachability.add_untargeted_dynamic_pop_action
-          1 (Test_dph.Target_condition_on_element_is_A(2,3))
+        1 (Test_dph.Target_condition_on_element_is_A(2,3))
       |> Test_reachability.add_edge 2 [Pop 'q'] 8
       |> Test_reachability.add_edge 3 [Pop 'q'] 9
       |> Test_reachability.add_edge 0 [Push 'b'] 11
       |> Test_reachability.add_untargeted_dynamic_pop_action
-          11 (Test_dph.Target_condition_on_element_is_A(12,13))
+        11 (Test_dph.Target_condition_on_element_is_A(12,13))
       |> Test_reachability.add_edge 12 [Pop 'q'] 18
       |> Test_reachability.add_edge 13 [Pop 'q'] 19
       |> Test_reachability.add_edge 0 [Push 'a'] 21
       |> Test_reachability.add_edge 0 [Push 'b'] 21
       |> Test_reachability.add_untargeted_dynamic_pop_action
-          21 (Test_dph.Target_condition_on_element_is_A(22,23))
+        21 (Test_dph.Target_condition_on_element_is_A(22,23))
       |> Test_reachability.add_edge 22 [Pop 'q'] 28
       |> Test_reachability.add_edge 23 [Pop 'q'] 29
       |> Test_reachability.add_start_state 0 [Push 'q']
@@ -273,10 +273,10 @@ let untargeted_dynamic_pop_reachability_test =
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
-        String_utils.indent 2 (Test_reachability.show_analysis analysis));
+                 String_utils.indent 2 (Test_reachability.show_analysis analysis));
     let states =
       List.sort compare @@ List.of_enum @@
-        Test_reachability.get_reachable_states 0 [Push 'q'] analysis
+      Test_reachability.get_reachable_states 0 [Push 'q'] analysis
     in
     lazy_logger `trace
       (fun () -> "states: " ^ String_utils.string_of_list string_of_int states);
@@ -286,25 +286,25 @@ let untargeted_dynamic_pop_reachability_test =
 let untargeted_dynamic_pop_function_reachability_test =
   "untargeted_dynamic_pop_function_reachability_test" >:: fun _ ->
     (* We're building this:
-      1. (S) -- Push 'q' --> (0)
-      2. (0) -- Push 'a', Push 'b', Push 'b' --> (1)
-      3. (0) -- Push 'a', Push 'a', Push 'a' --> (1)
-      4. (0) -- Push 'b', Push 'b' --> (1)
-      5. (0) -- Nop --> (1)
-      6. (n) -- Pop 'a' --> (n+1)  for 1 <= n <= 7
-      7. (n) -- Pop not 'a' --> (n+2) for 1 <= n <= 7
-      8. (n) -- Pop 'q' --> (n+20) for 1 <= n <= 7
+       1. (S) -- Push 'q' --> (0)
+       2. (0) -- Push 'a', Push 'b', Push 'b' --> (1)
+       3. (0) -- Push 'a', Push 'a', Push 'a' --> (1)
+       4. (0) -- Push 'b', Push 'b' --> (1)
+       5. (0) -- Nop --> (1)
+       6. (n) -- Pop 'a' --> (n+1)  for 1 <= n <= 7
+       7. (n) -- Pop not 'a' --> (n+2) for 1 <= n <= 7
+       8. (n) -- Pop 'q' --> (n+20) for 1 <= n <= 7
 
-      Given the above, we expect the following successful paths:
+       Given the above, we expect the following successful paths:
 
-      (S) ~1~> (0) ~2~> (1) ~7~> (3) ~7~> (5) ~6~> (6) ~7~> (8)
-      (S) ~1~> (0) ~2~> (1) ~7~> (3) ~7~> (5) ~6~> (6) ~8~> (26)
-      (S) ~1~> (0) ~3~> (1) ~6~> (2) ~6~> (3) ~6~> (4) ~7~> (6)
-      (S) ~1~> (0) ~3~> (1) ~6~> (2) ~6~> (3) ~6~> (4) ~8~> (24)
-      (S) ~1~> (0) ~4~> (1) ~7~> (3) ~7~> (5) ~7~> (7)
-      (S) ~1~> (0) ~4~> (1) ~7~> (3) ~7~> (5) ~8~> (25)
-      (S) ~1~> (0) ~5~> (1) ~7~> (3)
-      (S) ~1~> (0) ~5~> (1) ~8~> (21)
+       (S) ~1~> (0) ~2~> (1) ~7~> (3) ~7~> (5) ~6~> (6) ~7~> (8)
+       (S) ~1~> (0) ~2~> (1) ~7~> (3) ~7~> (5) ~6~> (6) ~8~> (26)
+       (S) ~1~> (0) ~3~> (1) ~6~> (2) ~6~> (3) ~6~> (4) ~7~> (6)
+       (S) ~1~> (0) ~3~> (1) ~6~> (2) ~6~> (3) ~6~> (4) ~8~> (24)
+       (S) ~1~> (0) ~4~> (1) ~7~> (3) ~7~> (5) ~7~> (7)
+       (S) ~1~> (0) ~4~> (1) ~7~> (3) ~7~> (5) ~8~> (25)
+       (S) ~1~> (0) ~5~> (1) ~7~> (3)
+       (S) ~1~> (0) ~5~> (1) ~8~> (21)
     *)
     let edge_function state =
       if state >= 1 && state < 8
@@ -314,7 +314,7 @@ let untargeted_dynamic_pop_function_reachability_test =
     let untargeted_dynamic_pop_action_fn state =
       if state >= 1 && state < 8
       then Enum.singleton
-            (Test_dph.Target_condition_on_element_is_A(state+1,state+2))
+          (Test_dph.Target_condition_on_element_is_A(state+1,state+2))
       else Enum.empty ()
     in
     let analysis =
@@ -325,16 +325,16 @@ let untargeted_dynamic_pop_function_reachability_test =
       |> Test_reachability.add_edge 0 [] 1
       |> Test_reachability.add_edge_function edge_function
       |> Test_reachability.add_untargeted_dynamic_pop_action_function
-          untargeted_dynamic_pop_action_fn
+        untargeted_dynamic_pop_action_fn
       |> Test_reachability.add_start_state 0 [Push 'q']
       |> Test_reachability.fully_close
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
-        String_utils.indent 2 (Test_reachability.show_analysis analysis));
+                 String_utils.indent 2 (Test_reachability.show_analysis analysis));
     let states =
       List.sort compare @@ List.of_enum @@
-        Test_reachability.get_reachable_states 0 [Push 'q'] analysis
+      Test_reachability.get_reachable_states 0 [Push 'q'] analysis
     in
     lazy_logger `trace
       (fun () -> "states: " ^ String_utils.string_of_list string_of_int states);
@@ -346,7 +346,7 @@ let targeted_dynamic_pop_chain_test =
     let analysis =
       Test_reachability.empty
       |> Test_reachability.add_edge 0
-          [Pop_dynamic_targeted(
+        [Pop_dynamic_targeted(
             Test_dph.Chain_two_push_1_of_2('a','b')); Push 'c'] 1
       |> Test_reachability.add_edge 1 [Pop 'c'; Pop 'b'; Pop 'a'; Pop 'x'] 2
       |> Test_reachability.add_start_state 0 [Push 'x']
@@ -354,21 +354,52 @@ let targeted_dynamic_pop_chain_test =
     in
     lazy_logger `trace
       (fun () -> "analysis:\n" ^
-        String_utils.indent 2 (Test_reachability.show_analysis analysis));
+                 String_utils.indent 2 (Test_reachability.show_analysis analysis));
     let states = Test_reachability.get_reachable_states 0 [Push 'x'] analysis in
     assert_equal (List.sort compare @@ List.of_enum states) [2]
 ;;
 
+let lazy_edge_function_test =
+  "lazy_edge_function_test" >:: fun _ ->
+    let analysis =
+      Test_reachability.empty
+      |> Test_reachability.add_edge_function
+        (fun state ->
+           if state < 10 || state > 99999998 then Enum.empty () else
+             List.enum [ ( [ Pop 'a' ]
+                         , state + 1
+                         )
+                       ; ( [ Pop 'b' ]
+                         , state + 2
+                         )
+                       ]
+        )
+      |> Test_reachability.add_start_state 0 [Push 'a']
+      |> Test_reachability.add_edge 0 [Push 'a'; Push 'a'; Push 'a'] 10
+      |> Test_reachability.add_edge 0 [Push 'b'; Push 'b'] 11
+      |> Test_reachability.fully_close
+    in
+    lazy_logger `trace
+      (fun () -> "analysis:\n" ^
+                 String_utils.indent 2 (Test_reachability.show_analysis analysis));
+    let states = Test_reachability.get_reachable_states 0 [Push 'a'] analysis in
+    assert_equal (List.sort compare @@ List.of_enum states) [14; 16];
+    let (nodes, edges) = Test_reachability.get_size analysis in
+    assert_bool "too many nodes" (nodes < 20);
+    assert_bool "too many edges" (edges < 100)
+;;
+
 let tests = "Test_reachability" >:::
-  [ immediate_reachability_test
-  ; immediate_non_reachable_test
-  ; two_step_reachability_test
-  ; cycle_reachability_test
-  ; edge_function_reachability_test
-  ; nondeterminism_reachability_test
-  ; targeted_dynamic_pop_reachability_test
-  ; targeted_dynamic_pop_nondeterminism_reachability_test
-  ; untargeted_dynamic_pop_reachability_test
-  ; untargeted_dynamic_pop_function_reachability_test
-  ]
+            [ immediate_reachability_test
+            ; immediate_non_reachable_test
+            ; two_step_reachability_test
+            ; cycle_reachability_test
+            ; edge_function_reachability_test
+            ; nondeterminism_reachability_test
+            ; targeted_dynamic_pop_reachability_test
+            ; targeted_dynamic_pop_nondeterminism_reachability_test
+            ; untargeted_dynamic_pop_reachability_test
+            ; untargeted_dynamic_pop_function_reachability_test
+            ; lazy_edge_function_test
+            ]
 ;;

--- a/test/test_reachability.ml
+++ b/test/test_reachability.ml
@@ -104,7 +104,12 @@ struct
   ;;
 end;;
 
-module Test_reachability = Pds_reachability.Make(Test_spec)(Test_dph);;
+module Test_reachability =
+  Pds_reachability.Make
+    (Test_spec)
+    (Test_dph)
+    (Pds_reachability_work_collection_templates.Work_stack)
+;;
 
 let immediate_reachability_test =
   "immediate_reachability_test" >:: fun _ ->


### PR DESCRIPTION
This PR changes the implementation of the PDR reachability analysis.  Instead of relying on mutual recursion to automatically close the PDR graph, the new algorithm reifies the remaining work as a collection of values.  The user may then "turn the crank" to complete one more unit of work (which may itself generate more work units).

This model results in more legible and modifiable code than the old spaghetti of recursive functions.  It also permits us to modify the order in which the collection dispenses work, which should assist in future optimizations.
